### PR TITLE
Add two new tests

### DIFF
--- a/menuconfig.s
+++ b/menuconfig.s
@@ -10,6 +10,7 @@
 #import "./tests/test_dmaTransparency.s"
 #import "./tests/test_spritesY200.s"
 #import "./tests/test_spritesBorderRelative.s"
+#import "./tests/test_16color8pxAltPalette.s"
 
 MenuConfig: {
 		.const IS_MENU = 1
@@ -96,6 +97,10 @@ MenuConfig: {
 
 				String("rrb boundary and wrap 40 column")
 				.word test_16colorRRBBoundary.Start
+				.byte IS_CODE
+
+				String("fcm 8px alternate palette 40 column")
+				.word test_16color8pxAltPalette.Start
 				.byte IS_CODE
 
 				String("return to main menu")

--- a/menuconfig.s
+++ b/menuconfig.s
@@ -9,6 +9,7 @@
 #import "./tests/test_chargenRowCount.s"
 #import "./tests/test_dmaTransparency.s"
 #import "./tests/test_spritesY200.s"
+#import "./tests/test_spritesBorderRelative.s"
 
 MenuConfig: {
 		.const IS_MENU = 1
@@ -125,6 +126,10 @@ MenuConfig: {
 				.word test_spritesY200.Start
 				.byte IS_CODE				
 
+				String("x-coord not affected by border width")
+				.word test_spritesBorderRelative.Start
+				.byte IS_CODE				
+
 				String("return to main menu")
 				.word Main
 				.byte IS_MENU
@@ -132,4 +137,4 @@ MenuConfig: {
 				.byte $00
 			}
 		}				
-} 
+}

--- a/tests/test_16color8pxAltPalette.s
+++ b/tests/test_16color8pxAltPalette.s
@@ -1,0 +1,77 @@
+test_16color8pxAltPalette: {
+	Desc_CharAttr:
+	//		 0         1         2         3         4         5         6         7         8
+	String(	"320x200 mode fcm 8px wide alt palette   "+
+		    "                                        "+
+		    "                                        "+
+		    "the two chars have different colors     ")
+
+	Start: {
+			//Set 16 bit char mode and enable FCM for chars > $FF
+			lda #$02
+			trb $d054
+			lda #$05
+			tsb $d054
+
+			//Clear H640 for 40 column mode
+			lda #$80
+			trb $d031
+
+			//Set row sizes
+			lda #$28
+			sta $d05e
+			lda #$50
+			sta $d058
+			lda #$00
+			sta $d059
+
+			jsr ClearScreen16
+
+			jsr ResetColRAMVector
+			jsr ResetScrRAMVector
+
+			ldy #$00
+			ldz #$00
+		!:
+			lda #<[[CHAR5]/$40]
+			sta (zpScrRAMVector), y
+			lda ColorRamTable, y
+			sta ((zpColRAMVector)), z
+			iny
+			inz
+
+			lda #>[[CHAR5]/$40]
+			sta (zpScrRAMVector), y
+			lda ColorRamTable, y
+			sta ((zpColRAMVector)),z
+			iny
+			inz
+
+			iny
+			iny
+			inz
+			inz
+
+			cpy #[__ColorRamTable - ColorRamTable]
+			bne !-
+
+			WriteDescription16(Desc_CharAttr)
+
+		//Loop until X is pressed
+		!Loop:
+			jsr ExitIfRunstop
+			jmp !Loop-
+
+
+		ColorRamTable:
+			.byte $00,$00 //8px wide
+			.byte $00,$00
+			.byte $00,$60 //8px wide alt palette
+			.byte $00,$00
+		__ColorRamTable:
+
+		Tests:
+
+	}
+
+}

--- a/tests/test_spritesBorderRelative.s
+++ b/tests/test_spritesBorderRelative.s
@@ -1,0 +1,63 @@
+test_spritesBorderRelative: {
+	Desc_Colors:
+	//		 0         1         2         3         4         5         6         7         8
+	String(	"display - sprite x-coordinate should not be affected by border width            "
+		  + "(the sprite above should not move horizontally)                                 ")
+
+	Start: {
+			//Enable a sprite
+			lda #$01
+			sta $d015
+
+			//Position sprite
+			ldx #$18
+			ldy #$32
+			stx $d000
+			sty $d001
+
+			//disable 16 color sprites
+			//disable extra wide sprites (16px)
+			lda #$00
+			sta $d06b
+			sta $d057
+
+			//Set 16bit sprite pointer and location
+			lda #$80
+			sta $d06e
+			lda #<SPRITE_POINTERS 
+			ldx #>SPRITE_POINTERS 
+			sta $d06c
+			stx $d06d
+			//Fill with sample sprite
+			lda #<[SPRITES_1BIT / $40]
+			ldx #>[SPRITES_1BIT / $40]
+			sta SPRITE_POINTERS
+			stx SPRITE_POINTERS+1
+
+			//Set color
+			lda #$01
+			sta $d027
+
+			WriteDescription(Desc_Colors)
+
+		//Loop until X is pressed
+		!Loop:
+			lda #$ff
+			jsr WaitForRaster
+
+			ldx BorderWidth
+			stx $d05c
+			dex
+			cpx #$48
+			bne !NoReset+
+			ldx #$50
+		!NoReset:
+			stx BorderWidth
+
+			jsr ExitIfRunstop
+			jmp !Loop-
+
+		BorderWidth:
+			.byte $50
+	}
+}

--- a/vic4tests.s
+++ b/vic4tests.s
@@ -138,6 +138,12 @@ ResetScreen: {
 		trb $d04d 
 		trb $d04f 
 
+		//Reset sprite heights to default
+		lda #$00
+		sta $d055
+		lda #$15
+		sta $d056
+
 		//Restore 8 bit char mode
 		lda #$07
 		trb $d054

--- a/vic4tests.s
+++ b/vic4tests.s
@@ -144,6 +144,12 @@ ResetScreen: {
 		lda #$15
 		sta $d056
 
+		//Reset border width
+		lda #$50
+		sta $d05c
+		lda #$3f
+		trb $d05d
+
 		//Restore 8 bit char mode
 		lda #$07
 		trb $d054


### PR DESCRIPTION
New tests based on observation of different behaviour in Xemu (merger branch) vs Nexys:

- Menu option A-E: A sprite's x-coordinate should not be affected by the border width
- Menu option B-F: An 8px wide char should be displayed using the alternate palette if the bold and reverse attributes are enabled

This PR also adds reset of sprite heights to `ResetScreen`.